### PR TITLE
I18n fix

### DIFF
--- a/src/datatable-core.js
+++ b/src/datatable-core.js
@@ -174,7 +174,7 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                     },
                     text: undefined,
                     clazz: undefined,
-                    messagesService: udtI18n(navigator.language || navigator.userLanguage),
+                    messagesService: udtI18n(navigator.languages || navigator.language || navigator.userLanguage),
                     transformKey: function(key, args) {
                         return this.messagesService.Messages(key, args);
                     }
@@ -762,10 +762,10 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                         that.displayResult = displayResultTmp;
                     } else {
                         if(configPagination.active && !that.isRemoteMode(configPagination.mode)){
-							_displayResult = $.extend(true,[],that._getAllResult().slice((configPagination.pageNumber*configPagination.numberRecordsPerPage), 
-								(configPagination.pageNumber*configPagination.numberRecordsPerPage+configPagination.numberRecordsPerPage)));										
+							_displayResult = $.extend(true,[],that._getAllResult().slice((configPagination.pageNumber*configPagination.numberRecordsPerPage),
+								(configPagination.pageNumber*configPagination.numberRecordsPerPage+configPagination.numberRecordsPerPage)));
 						}else{ //to manage all records or server pagination
-							_displayResult = $.extend(true,[],that._getAllResult());												    					
+							_displayResult = $.extend(true,[],that._getAllResult());
 						}
                         var displayResultTmp = [];
                         angular.forEach(_displayResult, function(value, key) {
@@ -1380,7 +1380,7 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                         if (this.config.pagination.active && !this.isRemoteMode(this.config.pagination.mode)) {
                             j = i + (this.config.pagination.pageNumber * this.config.pagination.numberRecordsPerPage);
                         }
-						this.allResult[j] = $.extend(true,{},this.displayResult[i].data);			    					
+						this.allResult[j] = $.extend(true,{},this.displayResult[i].data);
 
 
                     } else {
@@ -1828,7 +1828,7 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                     	},this);
                     }, this);
                 }
-            },	
+            },
             /**
              * Set columns configuration
              */
@@ -1898,13 +1898,13 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                         if (columns[i].convertValue !== undefined && columns[i].convertValue.active === true && (columns[i].convertValue.displayMeasureValue === undefined || columns[i].convertValue.saveMeasureValue === undefined)) {
                             throw "Columns config error: " + columns[i].property + " convertValue=active but convertValue.displayMeasureValue or convertValue.saveMeasureValue is missing";
                         }
-                        
+
                         if(null === columns[i].showFilter || undefined === columns[i].showFilter){
                             columns[i].showFilter = false;
                         }
                     }
 
-                    
+
                     var settings = $.extend(true, [], this.configColumnDefault, columns);
                     settings = $filter('orderBy')(settings, 'position');
 
@@ -1937,7 +1937,7 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
             setConfig: function(config) {
                 var settings = $.extend(true, {}, this.configDefault, config);
                 this.config = angular.copy(settings);
-                
+
                 if(!this.config.pagination.numberRecordsPerPageList){
                 	this.config.pagination.numberRecordsPerPageList = [{
                         number: 10,
@@ -1952,9 +1952,9 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                         number: 100,
                         clazz: ''
                     }];
-                	
+
                 }
-                
+
                 this.configMaster = angular.copy(settings);
                 if (this.config.columnsUrl) {
                     this.setColumnsConfigWithUrl();
@@ -1962,8 +1962,8 @@ factory('datatable', ['$http', '$filter', '$parse', '$window', '$q', 'udtI18n', 
                     this.setColumnsConfig(this.config.columns);
                 }
 
-                
-                
+
+
                 if (this.displayResult && this.displayResult.length > 0) {
                     this.computePaginationList();
                     this.computeDisplayResult();

--- a/src/services/udt-i18n.js
+++ b/src/services/udt-i18n.js
@@ -1,10 +1,10 @@
 ﻿angular.module('ultimateDataTableServices').
 factory('udtI18n', [function() {
-    		var constructor = function(preferedLanguageVar){
+    	var constructor = function(preferedLanguageVar) {
 				var udtI18n = {
-				    preferedLanguage : (preferedLanguageVar !== undefined ? preferedLanguageVar:"en"),
+				  preferedLanguage : (preferedLanguageVar !== undefined ? preferedLanguageVar : "en"),
 					translateTable : {
-						"fr":{
+						"fr": {
 							"result":"Résultats",
 							"date.format":"dd/MM/yyyy",
 							"datetime.format":"dd/MM/yyyy HH:mm:ss",
@@ -38,9 +38,9 @@ factory('udtI18n', [function() {
 							"datatable.button.generalGroup" : "Grouper toute la sélection",
 							"datatable.button.basicExportCSV" : "Exporter toutes les lignes",
 							"datatable.button.groupedExportCSV" : "Exporter les lignes groupées",
-							"datatable.button.showOnlyGroups" : "Voir uniquement les groupes"	
+							"datatable.button.showOnlyGroups" : "Voir uniquement les groupes"
 						},
-						"en":{
+						"en": {
 							"result":"Results",
 							"date.format":"MM/dd/yyyy",
 							"datetime.format":"MM/dd/yyyy HH:mm:ss",
@@ -76,7 +76,7 @@ factory('udtI18n', [function() {
 							"datatable.button.groupedExportCSV" : "Export only grouped lines",
 							"datatable.button.showOnlyGroups" : "See only group"
 						},
-						"nl":{
+						"nl": {
 							"result": "Resultaten",
 							"date.format": "dd/MM/yyyy",
 							"datetime.format": "dd/MM/yyyy HH:mm:ss",
@@ -113,16 +113,16 @@ factory('udtI18n', [function() {
 							"datatable.button.showOnlyGroups": "Toon alleen de groep"
 						}
 					},
-					
+
 					//Translate the key with the correct language
-					Messages : function(key){
-						  if(this.translateTable[this.preferedLanguage] === undefined){
-							this.preferedLanguage = "en";
+					Messages : function(key) {
+						  if(this.translateTable[this.preferedLanguage] === undefined) {
+						    this.preferedLanguage = "en";
 						  }
-						  
+
 						  var translatedString = this.translateTable[this.preferedLanguage][key];
 						  if(translatedString === undefined){
-							return key;
+							  return key;
 						  }
 						  for (var i=1; i < arguments.length; i++) {
 								translatedString = translatedString.replace("{"+(i-1)+"}", arguments[i]);
@@ -132,5 +132,5 @@ factory('udtI18n', [function() {
 				};
 				return udtI18n;
 			};
-    		return constructor;
+    	return constructor;
 }]);

--- a/src/services/udt-i18n.js
+++ b/src/services/udt-i18n.js
@@ -1,9 +1,49 @@
 ﻿angular.module('ultimateDataTableServices').
+/* A I18n service, that manage internal translation in udtI18n
+* follow the http://tools.ietf.org/html/rfc4646#section-2.2.4 spec
+* preferedLanguageVar can be a string or an array of string
+* https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage
+*/
 factory('udtI18n', [function() {
     	var constructor = function(preferedLanguageVar) {
 				var udtI18n = {
-				  preferedLanguage : (preferedLanguageVar !== undefined ? preferedLanguageVar : "en"),
-					translateTable : {
+          init: function() {
+            this.preferedLanguage = 'en';
+            // If preferedLanguageVar is undefined we keep the defaultLanguage
+            if(!preferedLanguageVar) {
+              return false;
+            }
+
+            var preferedLanguage = [];
+            if(!Array.isArray(preferedLanguageVar)) {
+              preferedLanguage.push(preferedLanguageVar);
+            } else {
+              preferedLanguage = preferedLanguageVar.slice();
+            }
+
+            preferedLanguage.some(function(language) {
+              // We first try to find the entire language string
+              // Primary Language Subtag with Extended Language Subtags
+              if(this.tanslationExist(language)) {
+                this.preferedLanguage = language;
+                return true;
+              }
+
+              // Then we try with only Primary Language Subtag
+              var splitedLanguages = language.split('-');
+              if(splitedLanguages > 1) {
+                var primaryLanguageSubtag = splitedLanguages[0];
+                if(this.tanslationExist(primaryLanguageSubtag)) {
+                  this.preferedLanguage = primaryLanguageSubtag;
+                  return true;
+                }
+              }
+            }, this);
+          },
+          tanslationExist: function(language) {
+            return this.translateTable[language] !== undefined;
+          },
+				  translateTable : {
 						"fr": {
 							"result":"Résultats",
 							"date.format":"dd/MM/yyyy",
@@ -116,20 +156,18 @@ factory('udtI18n', [function() {
 
 					//Translate the key with the correct language
 					Messages : function(key) {
-						  if(this.translateTable[this.preferedLanguage] === undefined) {
-						    this.preferedLanguage = "en";
-						  }
-
 						  var translatedString = this.translateTable[this.preferedLanguage][key];
-						  if(translatedString === undefined){
+						  if(translatedString === undefined) {
 							  return key;
 						  }
-						  for (var i=1; i < arguments.length; i++) {
+						  for (var i = 1; i < arguments.length; i++) {
 								translatedString = translatedString.replace("{"+(i-1)+"}", arguments[i]);
 						  }
 						  return translatedString;
 					}
 				};
+        
+        udtI18n.init();
 				return udtI18n;
 			};
     	return constructor;

--- a/src/services/udt-i18n.js
+++ b/src/services/udt-i18n.js
@@ -31,7 +31,7 @@ factory('udtI18n', [function() {
 
               // Then we try with only Primary Language Subtag
               var splitedLanguages = language.split('-');
-              if(splitedLanguages > 1) {
+              if(splitedLanguages.length > 1) {
                 var primaryLanguageSubtag = splitedLanguages[0];
                 if(this.tanslationExist(primaryLanguageSubtag)) {
                   this.preferedLanguage = primaryLanguageSubtag;
@@ -166,7 +166,7 @@ factory('udtI18n', [function() {
 						  return translatedString;
 					}
 				};
-        
+
         udtI18n.init();
 				return udtI18n;
 			};


### PR DESCRIPTION
Hello !

https://github.com/institut-de-genomique/Ultimate-DataTable/issues/14

I add a new init function in the I18n service that select the language. We can now give a String or an array of String to the I18n service constructor in order to use the [navigator.languages](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/languages) new generation browser function.

The init function try to find a translation with the all string (xx-XX) and if there is no translation for the extended language, we try with the primary language only (xx). The default language is 'en'.

The Messages function is now pure, because the check of the language is only on the init function.

Some additionnal [informations](http://tools.ietf.org/html/rfc4646#section-2.2.4). 
